### PR TITLE
Auto get system hostname, adds AD Join to the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,12 @@
 # domain_join #
-Bash script to prepare an Ubuntu Mate 16.04 host for joining to a MS Active Directory Domain.
+Bash script to prepare an Ubuntu Mate 16.04 host for joining to a MS Active Directory Domain. (Tested on Ubuntu 16.04 Server)
 
 ### Download and customise the script ###
 wget https://raw.githubusercontent.com/nathanfriend/domain_join/master/domain_join.sh
 
 chmod +x domain_join.sh  
-edit lines 3 through 9 for your environment.
+edit lines 3 through 10 for your environment.
 
 ### Run the script ###
 sudo -s  
 ./domain_join.sh
-
-Enter hostname to be joined (this will be shown  in Active directory)  
-Enter domain in uppercase.  
-After the script has run reboot host.  
-
-### Get token ###
-Get a Kerberos token using domain administrator credentials  
-kinit Administrator
-
-### Join domain ###
-
-net ads join -k
-

--- a/domain_join.sh
+++ b/domain_join.sh
@@ -4,15 +4,16 @@ domain="DEVDOMAIN.COM"
 shortdomain="DEVDOMAIN"
 dcip="192.168.100.2"
 dc="DEVDC-01.DEVDOMAIN.COM"
+domainjoinuser="Administrator"
 ntp="DEVDC-01.DEVDOMAIN.COM"
 shareserver="DEVDC-01.DEVDOMAIN.COM"
 homeshare="home"
 
-echo "Enter hostname: "
-read hostname
+#Get hostname
+$(hostname)
 
 #Install prerequisites
-apt-get -y install ntp ntpdate winbind samba libnss-winbind libpam-winbind krb5-locales krb5-user sssd libpam-mount cifs-utils
+apt-get -y install ntp ntpdate winbind samba libnss-winbind libpam-winbind krb5-locales krb5-user sssd libpam-mount cifs-utils lightdm
 
 #Edit network time config
 sed -i '18,21 s/^/#/' /etc/ntp.conf
@@ -441,3 +442,20 @@ greeter-hide-users=true
 greeter-show-manual-login=true
 allow-guest=false
 EOT
+
+#Get a Kerberos token using domain credentials
+echo 'Enter AD Administrator password: '
+if kinit $domainjoinuser ; then
+        #Join AD
+        if net ads join -k ; then
+                echo '.....................'
+                echo 'Complete'
+                echo '.....................'
+        else
+                echo 'Please ensure AD variables are correct and rerun this script.'
+        fi
+else
+        echo '.....................'
+        echo 'Retry by running "kinit Administrator" followed by "net ads join -k" or the whole script again.'
+        exit
+fi


### PR DESCRIPTION
- Auto gets system hostname,
- Adds AD join to the script with conditions if failures,
- Adds missing `lightdm` package
Tested and working on Ubuntu Server 16.04 LTS